### PR TITLE
Fix Docker build error in perplexity-ask Dockerfile

### DIFF
--- a/perplexity-ask/Dockerfile
+++ b/perplexity-ask/Dockerfile
@@ -1,8 +1,6 @@
 FROM node:22.12-alpine AS builder
 
-
-COPY . /app
-
+COPY perplexity-ask /app
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description
This PR fixes an issue with the Docker build process for the perplexity-ask MCP server. When attempting to build the Docker image using the command specified in the README, the build fails with an ENOENT error because it cannot find the package.json file.

## Problem
The current Dockerfile copies files from the root directory to the /app directory in the container:
```dockerfile
COPY . /app
```

However, the package.json file is located in the perplexity-ask subdirectory, causing npm install to fail with:
```
npm error code ENOENT
npm error syscall open
npm error path /app/package.json
npm error errno -2
npm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/app/package.json'
```

## Solution
This PR modifies the Dockerfile to copy files from the perplexity-ask directory instead:
```dockerfile
COPY perplexity-ask /app
```

This ensures that package.json and all other necessary files are correctly copied to the /app directory in the container, allowing the build to complete successfully.

## Testing Done
- Verified that the Docker build completes successfully with the modified Dockerfile
- Confirmed that the resulting Docker image runs correctly with the Perplexity API integration

## Related Documentation
The README already specifies the correct build command:
```bash
docker build -t mcp/perplexity-ask:latest -f perplexity-ask/Dockerfile .
```
No documentation changes are needed.

## Screenshots
N/A

## Additional Notes
This is a minimal change that fixes the build process without altering the functionality of the application.
