### PR TITLE
fix: correct COPY path in Dockerfile for proper build context

### DIFF
--- a/perplexity-ask/Dockerfile
+++ b/perplexity-ask/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22.12-alpine AS builder
 
-COPY perplexity-ask /app
+COPY . /app
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description
Fix the COPY instruction in Dockerfile to use the correct build context path.

## Problem
The current Dockerfile uses `COPY perplexity-ask /app` which assumes the build is run from the parent directory. This can cause build failures when the docker build command is run from within the perplexity-ask directory.

## Solution
Changed the COPY instruction to `COPY . /app` which uses the current build context, making the Dockerfile more robust regardless of where the build command is executed from.

## Testing
Verified the Docker build works correctly with this change when building from the perplexity-ask directory.