### PR TITLE
feat: add configurable base URL via PERPLEXITY_BASE_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Advanced reasoning and problem-solving using the `sonar-reasoning-pro` model. Pe
 1. Get your Perplexity API Key from the [API Portal](https://www.perplexity.ai/account/api/group)
 2. Replace `your_key_here` in the configurations below with your API key
 3. (Optional) Set timeout: `PERPLEXITY_TIMEOUT_MS=600000` (default: 5 minutes)
-4. (Optional) Set log level: `PERPLEXITY_LOG_LEVEL=DEBUG|INFO|WARN|ERROR` (default: ERROR)
+4. (Optional) Set custom base URL: `PERPLEXITY_BASE_URL=https://your-custom-url.com` (default: https://api.perplexity.ai)
+5. (Optional) Set log level: `PERPLEXITY_LOG_LEVEL=DEBUG|INFO|WARN|ERROR` (default: ERROR)
 
 ### Claude Code
 
@@ -145,6 +146,7 @@ For cloud or shared deployments, run the server in HTTP mode.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `PERPLEXITY_API_KEY` | Your Perplexity API key | *Required* |
+| `PERPLEXITY_BASE_URL` | Custom base URL for API requests | `https://api.perplexity.ai` |
 | `PORT` | HTTP server port | `8080` |
 | `BIND_ADDRESS` | Network interface to bind to | `0.0.0.0` |
 | `ALLOWED_ORIGINS` | CORS origins (comma-separated) | `*` |

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import type {
 import { ChatCompletionResponseSchema, SearchResponseSchema } from "./validation.js";
 
 const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
+const PERPLEXITY_BASE_URL = process.env.PERPLEXITY_BASE_URL || "https://api.perplexity.ai";
 
 export function getProxyUrl(): string | undefined {
   return process.env.PERPLEXITY_PROXY || 
@@ -71,7 +72,7 @@ export async function performChatCompletion(
   // Read timeout fresh each time to respect env var changes
   const TIMEOUT_MS = parseInt(process.env.PERPLEXITY_TIMEOUT_MS || "300000", 10);
 
-  const url = new URL("https://api.perplexity.ai/chat/completions");
+  const url = new URL(`${PERPLEXITY_BASE_URL}/chat/completions`);
   const body = {
     model: model,
     messages: messages,
@@ -187,7 +188,7 @@ export async function performSearch(
   // Read timeout fresh each time to respect env var changes
   const TIMEOUT_MS = parseInt(process.env.PERPLEXITY_TIMEOUT_MS || "300000", 10);
 
-  const url = new URL("https://api.perplexity.ai/search");
+  const url = new URL(`${PERPLEXITY_BASE_URL}/search`);
   const body: SearchRequestBody = {
     query: query,
     max_results: maxResults,


### PR DESCRIPTION
Allow users to override the default Perplexity API base URL by setting the PERPLEXITY_BASE_URL environment variable. Defaults to https://api.perplexity.ai if not set.