### PR TITLE
Enable custom LLM gateway configurations via configurable model constants

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,11 @@ import { ChatCompletionResponseSchema, SearchResponseSchema } from "./validation
 
 const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
 const PERPLEXITY_BASE_URL = process.env.PERPLEXITY_BASE_URL || "https://api.perplexity.ai";
+
+const SONAR_PRO_MODEL = process.env.SONAR_PRO_MODEL || "sonar-pro";
+const SONAR_REASONING_MODEL = process.env.SONAR_REASONING_MODEL || "sonar-reasoning-pro";
+const SONAR_DEEP_RESEARCH_MODEL = process.env.SONAR_DEEP_RESEARCH_MODEL || "sonar-deep-research";
+
 const VERSION = "0.9.0";
 
 export function getProxyUrl(): string | undefined {
@@ -98,7 +103,7 @@ async function makeApiRequest(
     clearTimeout(timeoutId);
     if (error instanceof Error && error.name === "AbortError") {
       throw new Error(`Request timeout: Perplexity API did not respond within ${TIMEOUT_MS}ms. Consider increasing PERPLEXITY_TIMEOUT_MS.`);
-    }
+      }
     throw new Error(`Network error while calling Perplexity API: ${error}`);
   }
   clearTimeout(timeoutId);
@@ -191,12 +196,12 @@ export async function consumeSSEStream(response: Response): Promise<ChatCompleti
 
 export async function performChatCompletion(
   messages: Message[],
-  model: string = "sonar-pro",
+  model: string = SONAR_PRO_MODEL,
   stripThinking: boolean = false,
   serviceOrigin?: string,
   options?: ChatCompletionOptions
 ): Promise<string> {
-  const useStreaming = model === "sonar-deep-research";
+  const useStreaming = model === SONAR_DEEP_RESEARCH_MODEL;
 
   const body: Record<string, unknown> = {
     model: model,
@@ -393,7 +398,7 @@ export function createPerplexityServer(serviceOrigin?: string) {
         ...(search_domain_filter && { search_domain_filter }),
         ...(search_context_size && { search_context_size }),
       };
-      const result = await performChatCompletion(messages, "sonar-pro", false, serviceOrigin, Object.keys(options).length > 0 ? options : undefined);
+      const result = await performChatCompletion(messages, SONAR_PRO_MODEL, false, serviceOrigin, Object.keys(options).length > 0 ? options : undefined);
       return {
         content: [{ type: "text" as const, text: result }],
         structuredContent: { response: result },
@@ -431,7 +436,7 @@ export function createPerplexityServer(serviceOrigin?: string) {
       const options = {
         ...(reasoning_effort && { reasoning_effort }),
       };
-      const result = await performChatCompletion(messages, "sonar-deep-research", stripThinking, serviceOrigin, Object.keys(options).length > 0 ? options : undefined);
+      const result = await performChatCompletion(messages, SONAR_DEEP_RESEARCH_MODEL, stripThinking, serviceOrigin, Object.keys(options).length > 0 ? options : undefined);
       return {
         content: [{ type: "text" as const, text: result }],
         structuredContent: { response: result },
@@ -473,7 +478,7 @@ export function createPerplexityServer(serviceOrigin?: string) {
         ...(search_domain_filter && { search_domain_filter }),
         ...(search_context_size && { search_context_size }),
       };
-      const result = await performChatCompletion(messages, "sonar-reasoning-pro", stripThinking, serviceOrigin, Object.keys(options).length > 0 ? options : undefined);
+      const result = await performChatCompletion(messages, SONAR_REASONING_MODEL, stripThinking, serviceOrigin, Object.keys(options).length > 0 ? options : undefined);
       return {
         content: [{ type: "text" as const, text: result }],
         structuredContent: { response: result },

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,7 +103,7 @@ async function makeApiRequest(
     clearTimeout(timeoutId);
     if (error instanceof Error && error.name === "AbortError") {
       throw new Error(`Request timeout: Perplexity API did not respond within ${TIMEOUT_MS}ms. Consider increasing PERPLEXITY_TIMEOUT_MS.`);
-      }
+    }
     throw new Error(`Network error while calling Perplexity API: ${error}`);
   }
   clearTimeout(timeoutId);


### PR DESCRIPTION
This PR refactors hardcoded model names into configurable environment variables with sensible defaults. This change enables the Perplexity MCP server to work seamlessly with custom LLM gateway deployments where model identifiers may differ from the standard Perplexity API naming conventions.

Changes:
- Added configurable model environment variables:
  - SONAR_PRO_MODEL (default: "sonar-pro")
  - SONAR_REASONING_MODEL (default: "sonar-reasoning-pro")  
  - SONAR_DEEP_RESEARCH_MODEL (default: "sonar-deep-research")
- Updated all references from hardcoded strings to use these constants

Why this is needed:
When deploying with a custom LLM gateway (e.g., using LiteLLM Proxy, Kong, or other middleware), model names may be mapped to different identifiers. For example:
- Gateway mapping: perplexity-sonar-pro → actual Perplexity API sonar-pro
- Internal naming: Your organization may use standardized model names across providers

Without this change, users would need to fork and modify the source code to use alternative model identifiers. Now they can simply set environment variables:

SONAR_PRO_MODEL=perplexity-sonar-pro
SONAR_REASONING_MODEL=perplexity-sonar-reasoning-pro
SONAR_DEEP_RESEARCH_MODEL=perplexity-sonar-deep-research

This maintains full backward compatibility while adding flexibility for enterprise deployments and custom gateway configurations.

Usage Example:
"environment": {
"PERPLEXITY_API_KEY": "your-custom-key", #e.g. litellm sk-xxx
                "PERPLEXITY_BASE_URL": "https://your-companies-llm-proxy",
                "SONAR_PRO_MODEL": "perplexity-sonar-pro",
                "SONAR_REASONING_MODEL": "perplexity-sonar-reasoning-pro",
                "SONAR_DEEP_RESEARCH_MODEL": "perplexity-sonar-deep-research"
            },