### PR TITLE
fix: sanitize Perplexity API error messages

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -418,20 +418,21 @@ describe("Perplexity MCP Server", () => {
       );
     });
 
-    it("should handle error text parse failures", async () => {
+    it("should not expose upstream error response details", async () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 500,
         statusText: "Internal Server Error",
-        text: async () => {
-          throw new Error("Cannot read error");
-        },
-      } as unknown as Response);
+        text: async () => "internal_trace=abc123; account=private-tier",
+      } as Response);
 
       const messages = [{ role: "user", content: "test" }];
 
       await expect(performChatCompletion(messages)).rejects.toThrow(
-        "Unable to parse error response"
+        "Perplexity API error: 500 Internal Server Error"
+      );
+      await expect(performChatCompletion(messages)).rejects.not.toThrow(
+        "internal_trace=abc123"
       );
     });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -418,6 +418,39 @@ describe("Perplexity MCP Server", () => {
       );
     });
 
+    it("should not expose JSON parse error details", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new Error("Invalid JSON containing secret_token=abc123");
+        },
+      } as unknown as Response);
+
+      const messages = [{ role: "user", content: "test" }];
+
+      await expect(performChatCompletion(messages)).rejects.toThrow(
+        "Failed to parse JSON response from Perplexity API"
+      );
+      await expect(performChatCompletion(messages)).rejects.not.toThrow(
+        "secret_token=abc123"
+      );
+    });
+
+    it("should not expose network error details", async () => {
+      global.fetch = vi.fn().mockRejectedValue(
+        new Error("Network failure with credential=private-token")
+      );
+
+      const messages = [{ role: "user", content: "test" }];
+
+      await expect(performChatCompletion(messages)).rejects.toThrow(
+        "Network error while calling Perplexity API"
+      );
+      await expect(performChatCompletion(messages)).rejects.not.toThrow(
+        "credential=private-token"
+      );
+    });
+
     it("should not expose upstream error response details", async () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import type {
   UndiciRequestOptions
 } from "./types.js";
 import { ChatCompletionResponseSchema, SearchResponseSchema } from "./validation.js";
+import { logger } from "./logger.js";
 
 const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
 const PERPLEXITY_BASE_URL = process.env.PERPLEXITY_BASE_URL || "https://api.perplexity.ai";
@@ -99,7 +100,8 @@ async function makeApiRequest(
     if (error instanceof Error && error.name === "AbortError") {
       throw new Error(`Request timeout: Perplexity API did not respond within ${TIMEOUT_MS}ms. Consider increasing PERPLEXITY_TIMEOUT_MS.`);
     }
-    throw new Error(`Network error while calling Perplexity API: ${error}`);
+    logger.error("Network error while calling Perplexity API", { error: String(error) });
+    throw new Error("Network error while calling Perplexity API");
   }
   clearTimeout(timeoutId);
 
@@ -110,8 +112,13 @@ async function makeApiRequest(
     } catch (parseError) {
       errorText = "Unable to parse error response";
     }
+    logger.error("Perplexity API error", {
+      status: response.status,
+      statusText: response.statusText,
+      body: errorText,
+    });
     throw new Error(
-      `Perplexity API error: ${response.status} ${response.statusText}\n${errorText}`
+      `Perplexity API error: ${response.status} ${response.statusText}`
     );
   }
 
@@ -228,7 +235,8 @@ export async function performChatCompletion(
         throw new Error("Invalid API response: missing or empty choices array");
       }
     }
-    throw new Error(`Failed to parse JSON response from Perplexity API: ${error}`);
+    logger.error("Failed to parse JSON response from Perplexity API", { error: String(error) });
+    throw new Error("Failed to parse JSON response from Perplexity API");
   }
 
   const firstChoice = data.choices[0];
@@ -292,7 +300,8 @@ export async function performSearch(
     const json = await response.json();
     data = SearchResponseSchema.parse(json);
   } catch (error) {
-    throw new Error(`Failed to parse JSON response from Perplexity Search API: ${error}`);
+    logger.error("Failed to parse JSON response from Perplexity Search API", { error: String(error) });
+    throw new Error("Failed to parse JSON response from Perplexity Search API");
   }
 
   return formatSearchResults(data);


### PR DESCRIPTION
## Summary

This PR prevents verbose upstream Perplexity API failure details from being returned to MCP clients.

**Vulnerability:** CWE-200: Exposure of Sensitive Information to an Unauthorized Actor

**Severity:** Medium

**Affected code:** `src/server.ts`, primarily `makeApiRequest`, `performChatCompletion`, and `performSearch`.

**Data flow:** a remote MCP client invokes a tool, the server calls the Perplexity API, an upstream HTTP/network/JSON parsing error occurs, and the thrown `Error` message is propagated by the MCP SDK back to the client in `result.content[].text`. Before this change, that message could include raw upstream response bodies or raw exception text.

## Fix

The client-facing errors now return stable, generic messages such as:

- `Perplexity API error: <status> <statusText>`
- `Network error while calling Perplexity API`
- `Failed to parse JSON response from Perplexity API`
- `Failed to parse JSON response from Perplexity Search API`

The detailed upstream body or exception text is still written to the existing server-side logger for operators, but it is no longer included in thrown errors that can be serialized back to MCP clients. This keeps diagnostics available without exposing provider internals, account details, traces, or other sensitive error content to remote callers.

## Security analysis

This is exploitable because the HTTP transport can be exposed remotely, binds to `0.0.0.0` in the public start mode, and can allow broad origins. A remote MCP client can trigger upstream failures, for example with invalid credentials, malformed upstream responses, API errors, or network/parse failures. Since thrown tool errors are returned to clients by the SDK, raw upstream response bodies and exception messages become client-visible.

The fix mitigates that by separating operational detail from client-facing error text. Clients still receive enough information to understand that the API request failed, while sensitive details stay in server-side logs.

Before submitting, we attempted to disprove this by checking whether existing transport controls, access controls, or framework behavior prevented exposure. They do not: the MCP SDK returns thrown tool errors to the caller, and the server can be run as an unauthenticated public HTTP service, so the raw error text was reachable without equivalent privileged access.

## Tests

Tested with:

```bash
npm test
```

Result: all tests passed (`3` test files, `80` tests).

Additional regression coverage was added to verify that upstream response bodies, JSON parse exception details, and network exception details are not present in client-facing thrown errors.

cc @lewiswigmore
