### PR TITLE
test: regression guard for #101 (no prompt-template wrapping; closes #101)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -174,6 +174,44 @@ describe("Perplexity MCP Server", () => {
         "Network error while calling Perplexity API"
       );
     });
+
+    // Regression test for #101 — verifies that the official server does NOT
+    // wrap user queries in any prompt template (the bug reported in #101 was
+    // in the third-party DaInfernalCoder/researcher-mcp fork, not this repo).
+    // If anyone re-introduces template wrapping in this repo, this test will
+    // fail loudly.
+    it("should forward user messages verbatim to the API (regression: #101)", async () => {
+      const mockResponse = {
+        choices: [{ message: { content: "ok" } }],
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const userQuery =
+        "Cleveland Fed inflation nowcast March 2026 CPI estimate";
+      const messages = [{ role: "user", content: userQuery }];
+
+      await performChatCompletion(messages, "sonar-reasoning-pro");
+
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+      const [, init] = fetchMock.mock.calls[0];
+      const sentBody = JSON.parse((init as RequestInit).body as string);
+
+      // The body must contain exactly the user's message — no prompt template
+      // around it, no synthetic system message added by the server.
+      expect(sentBody.messages).toEqual(messages);
+      expect(sentBody.messages[0].content).toBe(userQuery);
+
+      // Defensive guards against known template keywords that poisoned search
+      // results in the third-party fork (see issue #101).
+      const sentJson = (init as RequestInit).body as string;
+      expect(sentJson).not.toContain("error messages, logs, code snippets");
+      expect(sentJson).not.toContain("specific situation");
+      expect(sentJson).not.toContain("step-by-step reasoning based on the actual context");
+    });
   });
 
   describe("performSearch", () => {


### PR DESCRIPTION
## Summary

Closes #101.

## TL;DR

The bug reported in #101 is **not in this repository**. It is in the third-party fork [`DaInfernalCoder/researcher-mcp`](https://github.com/DaInfernalCoder/researcher-mcp), published on npm as `perplexity-mcp` v0.2.3. The reporter (@SangeethsivanSivakumar) [confirmed this themselves](https://github.com/perplexityai/modelcontextprotocol/issues/101#issuecomment-) while debugging:

> Debugged the MCP wrapper (`perplexity-mcp` npm package v0.2.3 from `DaInfernalCoder/researcher-mcp`).

The official `@perplexity-ai/mcp-server` (this repo) forwards user messages to `api.perplexity.ai` verbatim. There is no template wrapping in any of the four tool handlers (`perplexity_ask`, `perplexity_research`, `perplexity_reason`, `perplexity_search`).

## What this PR does

Adds a **regression guard** so we can never accidentally introduce the third-party fork's bug:

1. Calls `performChatCompletion` with a representative user query.
2. Asserts the outgoing request body's `messages` field equals the input verbatim.
3. Defensively asserts that none of the poisoning keywords from the third-party fork's template (`"error messages, logs, code snippets"`, `"specific situation"`, `"step-by-step reasoning based on the actual context"`) appear in the outgoing JSON.

If anyone ever re-introduces wrapper-template logic into this server, this test fails immediately.

## Why no version bump

No code change, no behavior change — only a unit test. No 0.9.1 release is needed for this PR. The P0.1 LLM-provenance envelope PR (#105) is the change worth a minor bump; if that lands we can roll the version there.

## Test plan

- `npm test`: **79 passed / 79** (was 78). The new test "should forward user messages verbatim to the API (regression: #101)" passes.

## Recommended issue handling

When this PR merges, close #101 with a comment pointing the reporter at `DaInfernalCoder/researcher-mcp` (where the actual `prompt = template + query` code lives). Credit to @SangeethsivanSivakumar for the detailed root-cause analysis — their work narrowed this down to the exact npm package and patch.
