### PR TITLE
fix(http): create a fresh MCP server per request in stateless HTTP mode

### DIFF
--- a/src/http.config.test.ts
+++ b/src/http.config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { Server } from "http";
 import { createHttpApp, buildAllowedHosts } from "./http.js";
+import * as serverModule from "./server.js";
 
 /**
  * Tests for the HTTP transport's CORS, bind, and Host header configuration.
@@ -348,6 +349,55 @@ describe("HTTP transport configuration", () => {
       });
 
       expect(status).toBe(200);
+    });
+  });
+
+  describe("stateless server lifecycle", () => {
+    // Regression: createHttpApp built a single McpServer at module scope and
+    // called mcpServer.connect(transport) on every request. The stateless
+    // StreamableHTTP transport (sessionIdGenerator: undefined) has no session
+    // to reuse, so while one request's transport is still open a concurrent
+    // request calling connect() on the same server threw "Already connected to
+    // a transport" -> HTTP 500. Real MCP clients overlap requests (an open
+    // stream plus follow-up calls), so this fired in practice. The fix is a
+    // fresh server + transport per request.
+    it("creates a fresh server per request, not one shared server", async () => {
+      const spy = vi.spyOn(serverModule, "createPerplexityServer");
+      await start();
+      // Ignore anything created while building the app; count per-request only.
+      spy.mockClear();
+
+      const rpc = (id: number) =>
+        fetch(`${baseUrl}/mcp`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "regression", version: "0" },
+            },
+          }),
+        });
+
+      const first = await rpc(1);
+      const second = await rpc(2);
+
+      // Both requests must succeed. A shared module-scope server made the
+      // second request throw "Already connected to a transport" -> 500.
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+
+      // And the fix's invariant: one server is created per request (a shared
+      // server would be created at app-construction time and reused, i.e. zero
+      // per-request creations after mockClear).
+      expect(spy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/http.ts
+++ b/src/http.ts
@@ -124,10 +124,16 @@ export function createHttpApp(options: HttpAppOptions): Express {
 
   app.use(express.json());
 
-  const mcpServer = createPerplexityServer();
-
   app.all("/mcp", async (req, res) => {
     try {
+      // Create a fresh server + transport per request. The stateless
+      // StreamableHTTP transport (sessionIdGenerator: undefined) keeps no
+      // session to reuse, and an McpServer can only be connected to one
+      // transport at a time. Sharing a single server across requests makes any
+      // request that arrives while another is still open throw "Already
+      // connected to a transport" and return 500 — which breaks every
+      // multi-request MCP client. This mirrors the SDK's stateless example.
+      const mcpServer = createPerplexityServer();
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true,
@@ -135,6 +141,7 @@ export function createHttpApp(options: HttpAppOptions): Express {
 
       res.on("close", () => {
         transport.close();
+        mcpServer.close();
       });
 
       await mcpServer.connect(transport);


### PR DESCRIPTION
## Summary

In HTTP mode, `createHttpApp` builds a single `McpServer` at construction and calls `mcpServer.connect(transport)` on every `/mcp` request. With the stateless streamable-HTTP transport (`sessionIdGenerator: undefined`) there is no session to reuse, so once one request's transport is connected, any request arriving before it closes calls `connect()` on the already-connected server and throws `Already connected to a transport … use a separate Protocol instance per connection` → HTTP 500.

This breaks multi-request MCP clients: `initialize` succeeds, `tools/list` 500s, and no tools register. (A strictly-sequential `curl` dodges it because `res.on("close")` frees the shared server between requests, which is why it isn't obvious in one-shot testing.)

Fixes #117.

## Change

- Move `createPerplexityServer()` into the `/mcp` handler so each request gets its own server + transport (the SDK's stateless pattern), and close the per-request server on response close.
- Add a regression test asserting a fresh server is created per request. It fails against the shared-server code (`expected "createPerplexityServer" to be called 2 times, but got 0 times`) and passes with the fix.

## Verification

- `npm test` — 91 passing (new test included).
- `npm run build` — clean.
- Verified end-to-end against a live MCP client: before, `initialize` succeeded but `tools/list` 500'd and no tools registered; after, the full `initialize → tools/list → tools/call` flow works.
