### PR TITLE
fix(http): create a server instance per request in stateless HTTP mode

### DIFF
--- a/src/http.config.test.ts
+++ b/src/http.config.test.ts
@@ -350,4 +350,47 @@ describe("HTTP transport configuration", () => {
       expect(status).toBe(200);
     });
   });
+
+  describe("stateless request handling", () => {
+    it("serves multiple sequential requests on one app instance", async () => {
+      await start();
+
+      const listTools = () =>
+        fetch(`${baseUrl}/mcp`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/list",
+            params: {},
+          }),
+        });
+
+      // A single server instance can only bind one transport, so the app must
+      // build a fresh pair per request; before that fix the second request
+      // failed with a 500 "Already connected to a transport".
+      const first = await listTools();
+      expect(first.status).toBe(200);
+
+      const second = await listTools();
+      expect(second.status).toBe(200);
+      const data = await second.json();
+      expect(data.result.tools).toHaveLength(4);
+    });
+
+    it("serves the health endpoint", async () => {
+      await start();
+
+      const response = await fetch(`${baseUrl}/health`);
+      expect(response.ok).toBe(true);
+      expect(await response.json()).toEqual({
+        status: "ok",
+        service: "perplexity-mcp-server",
+      });
+    });
+  });
 });

--- a/src/http.ts
+++ b/src/http.ts
@@ -124,17 +124,19 @@ export function createHttpApp(options: HttpAppOptions): Express {
 
   app.use(express.json());
 
-  const mcpServer = createPerplexityServer();
-
   app.all("/mcp", async (req, res) => {
     try {
+      // Stateless mode: a Protocol instance supports one transport, so build
+      // a fresh server + transport pair per request.
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true,
       });
+      const mcpServer = createPerplexityServer();
 
       res.on("close", () => {
         transport.close();
+        mcpServer.close();
       });
 
       await mcpServer.connect(transport);


### PR DESCRIPTION
Stateless HTTP mode reuses one McpServer across requests, but a Protocol instance only supports one transport, so the second POST in any session 500s with "Already connected to a transport". MCP init is itself a POST, so every HTTP client breaks on its first real request (`npm run start:http` and Docker HTTP mode).

- Build a fresh server + transport pair per request (the SDK's stateless pattern) and close both when the response closes
- Reproduced on main with the lockfile SDK (1.27.1) using the official streamable HTTP client
- Adds a regression test (two sequential POSTs against one app instance) and a `/health` test

Fixes #117.
