### PR TITLE
ci: fix npm publish job broken by npm 12's Node engine requirement

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          
+
       - name: Get latest npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@12
         
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The publish workflow failed before publishing anything: the "Get latest npm" step installs npm@latest, and npm 12 now requires Node >= 22 while the job runs Node 20.

- Bumps the publish job to Node 24
- Pins the npm upgrade to the 12.x major so a future npm engine-floor bump cannot break releases again
- Keeps the npm upgrade step since trusted publishing (OIDC) requires npm >= 11.5, newer than Node's bundled npm

No package code changes. After merge, the 1.0.0 release can be retried via workflow_dispatch.