### PR TITLE
Package as an Agent Plugin

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -5,11 +5,15 @@ on:
     paths:
       - '.claude-plugin/**'
       - 'package.json'
+      - 'plugin.json'
+      - 'mcp.json'
   push:
     branches: [main]
     paths:
       - '.claude-plugin/**'
       - 'package.json'
+      - 'plugin.json'
+      - 'mcp.json'
 
 jobs:
   validate:
@@ -43,4 +47,24 @@ jobs:
           echo "Validating marketplace.json syntax..."
           cat .claude-plugin/marketplace.json | jq empty
           echo "✓ JSON syntax is valid"
+
+      - name: Validate Agent Plugins Manifests
+        run: |
+          curl -fsSL --retry 3 -o /tmp/plugin.schema.json https://agent-plugins.org/schemas/1.0.0/plugin.schema.json
+          curl -fsSL --retry 3 -o /tmp/mcp.schema.json https://agent-plugins.org/schemas/1.0.0/mcp.schema.json
+          npx --yes ajv-cli@5 validate --spec=draft2020 -s /tmp/plugin.schema.json -d plugin.json
+          npx --yes ajv-cli@5 validate --spec=draft2020 -s /tmp/mcp.schema.json -d mcp.json
+          echo "✓ plugin.json and mcp.json conform to Agent Plugins 1.0.0 schemas"
+
+      - name: Check Version Sync
+        run: |
+          PKG=$(jq -r '.version' package.json)
+          PLUGIN=$(jq -r '.version' plugin.json)
+          MARKETPLACE=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+          echo "package.json=$PKG plugin.json=$PLUGIN marketplace.json=$MARKETPLACE"
+          if [ "$PKG" != "$PLUGIN" ] || [ "$PKG" != "$MARKETPLACE" ]; then
+            echo "Error: version mismatch across package.json, plugin.json, and .claude-plugin/marketplace.json"
+            exit 1
+          fi
+          echo "✓ Versions are in sync"
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ claude
 codex mcp add perplexity --env PERPLEXITY_API_KEY="your_key_here" -- npx -y @perplexity-ai/mcp-server
 ```
 
+### Agent Plugins
+
+This repository is packaged as an [Agent Plugin](https://agent-plugins.org), so clients that support the standard can install it directly from this repository. The Agent Plugins format does not carry secrets, so set the `PERPLEXITY_API_KEY` environment variable through your client's plugin or MCP settings.
+
 ### Other MCP Clients
 
 Most clients can be configured manually using the same `mcpServers` wrapper in their client config (as shown for Cursor). If a client has a different schema, check its docs for the exact wrapper format.

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "perplexity": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@perplexity-ai/mcp-server"]
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "perplexity",
+  "version": "1.2.0",
+  "description": "Real-time web search, reasoning, and research through Perplexity's API",
+  "author": {
+    "name": "Perplexity AI",
+    "email": "api@perplexity.ai"
+  },
+  "homepage": "https://docs.perplexity.ai/guides/mcp-server",
+  "repository": "https://github.com/perplexityai/modelcontextprotocol",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "search",
+    "web-search",
+    "perplexity",
+    "research",
+    "reasoning",
+    "ai"
+  ]
+}


### PR DESCRIPTION
Adds `plugin.json` and `mcp.json` so this repo installs as an [Agent Plugin](https://agent-plugins.org) in clients that support the new standard (ChatGPT, Codex, Cursor, GitHub Copilot, Kiro, VS Code).

No server changes, and the existing Claude Code plugin packaging is unchanged. Both manifests validate against the official 1.0.0 schemas.

One note: the Agent Plugins spec does not allow secrets in `mcp.json`, so `PERPLEXITY_API_KEY` is set through the client's plugin or MCP settings instead. Added a short README section covering this.